### PR TITLE
Improved Dev Previews on observer via "dev credentials" file

### DIFF
--- a/observer/.gitignore
+++ b/observer/.gitignore
@@ -1,3 +1,4 @@
+dev-credentials.json
 .DS_Store
 node_modules
 /.svelte-kit

--- a/observer/src/routes/dev-login/+page.server.ts
+++ b/observer/src/routes/dev-login/+page.server.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import type { PageServerLoad } from "./$types";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const load: PageServerLoad = async () => {
+  try {
+    const credPath = resolve(__dirname, "../../../dev-credentials.json");
+    const creds = JSON.parse(readFileSync(credPath, "utf-8"));
+    return { creds };
+  } catch (err) {
+    console.error("Failed to load dev-credentials:", err);
+    return { creds: null };
+  }
+};

--- a/observer/src/routes/dev-login/+page.svelte
+++ b/observer/src/routes/dev-login/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+
+  export let data;
+
+  onMount(() => {
+    if (data.creds) {
+      const c = data.creds;
+      localStorage.setItem("loggedIn", "true");
+      localStorage.setItem("token", c.token);
+      localStorage.setItem("accountId", c.accountId);
+      localStorage.setItem("accountEmail", c.accountEmail);
+      localStorage.setItem("email", c.email);
+      localStorage.setItem("userNode", c.userNode);
+      goto(c.redirectTo || "/");
+    } else {
+      goto("/");
+    }
+  });
+</script>
+
+<p>Logging in...</p>


### PR DESCRIPTION
As the title suggests, there's a new dev-credentials.json file you can use so that when you start up a dev preview so that you don't have to worry about logins and the choose location screen.