### PR TITLE
Multiple fixes to stripe-related issues based on customer tickets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,37 @@ This monorepo structure keeps both projects in sync and allows coordinated devel
 
 ---
 
+## Git Workflow Standards
+
+**File Changes Only**
+- Never commit files - only modify them
+- User handles all commits
+- Focus exclusively on code changes
+
+**Remote Operations**
+- Never push to remote unless explicitly asked
+- When user requests a push:
+  - Ask for permission first
+  - Specify which branch will be pushed
+  - Confirm before proceeding
+- For wider git operations (branch creation, history changes, rebases):
+  - Ask permission and clarify intent first
+  - Specify affected branches
+
+**Branch Naming**
+- Use format: `claude/feature-name`
+- Example: `claude/backup-fix`, `claude/auth-improvement`
+
+**Merge to Main**
+- If merging to main: Always create PR first
+- User unlikely to request this, but standard if asked
+
+**Commit Messages**
+- Current format acceptable if user requests commits (unlikely)
+- Format: "Brief description of changes"
+
+---
+
 ## Project Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,14 @@ This monorepo structure keeps both projects in sync and allows coordinated devel
 - Use format: `claude/feature-name`
 - Example: `claude/backup-fix`, `claude/auth-improvement`
 
+**Branch Creation & Tracking**
+- When creating a feature branch, ensure it tracks the correct remote branch
+- **CRITICAL**: New branches created by Claude must use: `git checkout -b claude/feature-name origin/claude/feature-name`
+- Do NOT let a feature branch track `origin/main` - this causes commits to push to main instead of the feature branch
+- Verify tracking with: `git branch -vv` (should show `[origin/claude/feature-name]`, not `[origin/main]`)
+- If tracking is wrong, fix with: `git branch --set-upstream-to=origin/claude/feature-name claude/feature-name`
+- Example of what went wrong: A `claude/backup-fix` branch that tracked `origin/main` caused commits to appear on main remotely while appearing on the feature branch locally
+
 **Merge to Main**
 - If merging to main: Always create PR first
 - User unlikely to request this, but standard if asked

--- a/observer/src/lib/components/layout/Nav.svelte
+++ b/observer/src/lib/components/layout/Nav.svelte
@@ -345,7 +345,7 @@ Invalid Account
   id="serverCard{parseInt(server.split(":")[0])}"
   class="neutralGradientStrokeB flex md:max-lg:px-4 gap-2.5 items-center p-3 w-12 sm:w-32 truncate md:w-full md:h-[5.5rem] rounded-lg bg-base-200 cursor-pointer"
 >
-<ExpiredServerCard id={parseInt(server.split(":")[0])} timestamp={server.split(":")[2]}/>
+<ExpiredServerCard id={parseInt(server.split(":")[0])} timestamp={server.split(":")[2]} cause={server.split(":")[3]}/>
 </a>
 {:else}
 {#if parseInt(server.id) + 10000 == slug}

--- a/observer/src/lib/components/ui/ExpiredServerCard.svelte
+++ b/observer/src/lib/components/ui/ExpiredServerCard.svelte
@@ -36,8 +36,15 @@
 
   export let id: number;
   export let timestamp: number = 0;
+  export let cause: string = "unknown";
 
   const daysUntil = timestamp => Math.ceil((timestamp * 1000 - Date.now()) / (1000 * 60 * 60 * 24));
+
+  const causeText = (cause: string) => {
+    if (cause === "payment_failed") return "Unable to charge payment method.";
+    if (cause === "canceled") return "Subscription was cancelled.";
+    return null;
+  };
 </script>
 
 
@@ -57,7 +64,12 @@
         Slot {parseInt(id)} has been freed up due to expired subscription.
       {/if}
     </p>
-        <p class="font-poppins text-xs mb-0.5 -mt-1">
+    {#if causeText(cause)}
+    <p class="font-poppins text-xs mb-0.5 -mt-1 opacity-75">
+      Cause: {causeText(cause)}
+    </p>
+    {/if}
+    <p class="font-poppins text-xs mb-0.5 -mt-1">
       Contact support to renew.
     </p>
   </div>

--- a/observer/src/routes/(login)/billing/+page.svelte
+++ b/observer/src/routes/(login)/billing/+page.svelte
@@ -2,7 +2,7 @@
   import { apiurl, customerPortalLink } from "$lib/scripts/req";
   import { t, locale, locales } from "$lib/scripts/i18n";
   import { browser } from "$app/environment";
-  import { ClipboardList, MessagesSquare, CreditCard, Server, CheckCircle, XCircle, AlertCircle, Clock, ExternalLink, RefreshCw } from "lucide-svelte";
+  import { ClipboardList, MessagesSquare, CreditCard, Server, CheckCircle, XCircle, AlertCircle, Clock, ExternalLink, Zap } from "lucide-svelte";
   import { alert } from "$lib/scripts/utils";
 
   let servers = [];
@@ -43,30 +43,95 @@
     }
   }
 
-  let syncing = false;
+  let showFixIssueModal = false;
+  let selectedIssue: 'planUpgrade' | 'resubscribedSlot' | null = null;
+  let modalPlans = [];
+  let modalServers = [];
+  let planAssignments: Record<string, string> = {};
+  let modalLoading = false;
+  let modalError = '';
+  let modalSubmitting = false;
 
-  async function syncPlan() {
-    syncing = true;
+  async function openFixIssueModal() {
+    modalLoading = true;
+    modalError = '';
+    planAssignments = {};
+
     try {
-      const res = await fetch(apiurl + "info/syncplan", {
-        method: "POST",
+      // Load current plans and servers
+      const response = await fetch(apiurl + "info/billing", {
+        method: "GET",
         headers: {
           username: localStorage.getItem("accountEmail"),
           token: localStorage.getItem("token"),
         },
       });
-      const json = await res.json();
-      if (json.changed) {
-        alert("Plan updated — restart your server to apply the new RAM and storage allocation.", "success");
-      } else if (json.reason === "no_active_subscription") {
-        alert("No active subscription found. If you just subscribed, it may take a moment to activate.", "info");
+
+      const data = await response.json();
+
+      // Process plans
+      const planCounts: Record<string, number> = {};
+      data.subscriptions.forEach((sub: any) => {
+        planCounts[sub.name] = (planCounts[sub.name] || 0) + 1;
+      });
+
+      modalPlans = Object.entries(planCounts).map(([name, count]) => ({
+        name,
+        count,
+        displayName: `${count}x ${name.charAt(0).toUpperCase() + name.slice(1)} Plan`
+      }));
+
+      // Process servers - include all servers to show pending status
+      modalServers = data.servers.map((server: any) => {
+        const isPending = server.plan === "not created yet";
+        return {
+          id: server.id,
+          software: server.software,
+          version: server.version,
+          currentPlan: server.plan,
+          isPending
+        };
+      });
+
+      showFixIssueModal = true;
+    } catch (e) {
+      modalError = "Failed to load plans and servers";
+      console.error(e);
+    }
+
+    modalLoading = false;
+  }
+
+  async function submitPlanUpdates() {
+    modalSubmitting = true;
+
+    try {
+      const response = await fetch(apiurl + "info/updatePlans", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          username: localStorage.getItem("accountEmail"),
+          token: localStorage.getItem("token"),
+        },
+        body: JSON.stringify({ planAssignments }),
+      });
+
+      const data = await response.json();
+
+      if (data.updated && data.updated.length > 0) {
+        alert(`Updated ${data.updated.length} server(s). Server restart required to apply changes.`, "success");
+        showFixIssueModal = false;
+      } else if (data.errors && data.errors.length > 0) {
+        modalError = "Some servers failed to update: " + data.errors.join(", ");
       } else {
-        alert("Your plan is already up to date.", "success");
+        alert("No changes were made", "info");
       }
     } catch (e) {
-      alert("Failed to sync plan. Please try again.", "error");
+      modalError = "Failed to update plans";
+      console.error(e);
     }
-    syncing = false;
+
+    modalSubmitting = false;
   }
 
   function getStatusColor(status: string) {
@@ -160,14 +225,6 @@
           {$t("button.newsubscribe")}
         {/if}
       </a>
-      <button
-        class="btn btn-outline gap-2"
-        on:click={syncPlan}
-        disabled={syncing}
-      >
-        <RefreshCw size="18" class="mr-1.5 {syncing ? 'animate-spin' : ''}" />
-        {syncing ? "Refreshing..." : "Refresh Plans"}
-      </button>
     </div>
 
     <!-- Two Column Layout: Subscriptions (Left) | Servers (Right) -->
@@ -276,6 +333,47 @@
       </div>
     </div>
 
+    <!-- Subscription Tools -->
+    <div class="card bg-base-100 shadow-lg">
+      <div class="card-body p-4">
+        <div class="flex items-center justify-between">
+          <h2 class="card-title flex items-center gap-2 text-base">
+            <Zap size="18" class="text-info" />
+            Subscription Tools
+          </h2>
+          <button
+            class="btn btn-sm btn-primary"
+            on:click={openFixIssueModal}
+            disabled={!selectedIssue}
+          >
+            Fix Issue
+          </button>
+        </div>
+        <div class="space-y-2 mt-3">
+          <label class="flex items-center gap-3 p-2 rounded hover:bg-base-200/50 transition cursor-pointer">
+            <input
+              type="radio"
+              name="subscription-issue"
+              class="radio radio-sm"
+              value="planUpgrade"
+              bind:group={selectedIssue}
+            />
+            <span class="text-sm">Plan upgrade not applied</span>
+          </label>
+          <label class="flex items-center gap-3 p-2 rounded hover:bg-base-200/50 transition cursor-pointer">
+            <input
+              type="radio"
+              name="subscription-issue"
+              class="radio radio-sm"
+              value="resubscribedSlot"
+              bind:group={selectedIssue}
+            />
+            <span class="text-sm">Re-subscribed, can't use server slot</span>
+          </label>
+        </div>
+      </div>
+    </div>
+
     <!-- Refunds Info Card -->
     <div class="card bg-base-100 shadow-lg">
       <div class="card-body">
@@ -318,3 +416,110 @@
     </div>
   </div>
 </div>
+
+<!-- Fix Issue Modal -->
+{#if showFixIssueModal}
+  <div class="modal modal-open">
+    <div class="modal-box max-w-3xl max-h-[80vh] overflow-y-auto">
+      <div class="mb-4">
+        <h3 class="font-bold text-lg">
+          {selectedIssue === 'planUpgrade' ? 'Update Server Plans' : 'Reassign Server Slot'}
+        </h3>
+        {#if selectedIssue === 'planUpgrade'}
+          <p class="text-sm text-gray-400 mt-1">Let's make sure your plans are allocated properly</p>
+        {/if}
+      </div>
+
+      {#if modalLoading}
+        <div class="py-6 text-center">
+          <span class="loading loading-spinner loading-lg"></span>
+        </div>
+      {:else if modalError}
+        <div class="alert alert-error mb-4">
+          <span>{modalError}</span>
+        </div>
+      {:else if selectedIssue === 'planUpgrade'}
+        <div class="space-y-4">
+          <!-- Assignment Interface -->
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 min-h-[200px]">
+            <!-- Servers (Left) -->
+            <div>
+              <p class="text-sm font-semibold text-gray-400 mb-3">Your Servers:</p>
+              <div class="space-y-2">
+                {#each modalServers as server, idx}
+                  <div class="flex items-center gap-2 p-2 bg-base-200/30 rounded">
+                    {#if server.isPending}
+                      <div class="flex-1">
+                        <p class="text-xs text-gray-500 font-mono">{server.id}</p>
+                        <p class="text-xs text-gray-600">Pending creation</p>
+                      </div>
+                      <div class="badge badge-ghost badge-sm">—</div>
+                    {:else}
+                      <div class="flex-1">
+                        <p class="text-xs font-mono text-gray-300">Slot {server.id} - {server.software.charAt(0).toUpperCase() + server.software.slice(1)} {server.version}</p>
+                      </div>
+                      <select
+                        class="select select-sm select-bordered w-20"
+                        bind:value={planAssignments[server.id]}
+                        disabled={server.isPending}
+                      >
+                        <option value="" disabled selected>—</option>
+                        {#each modalPlans as plan, letterIdx}
+                          <option value={plan.name}>
+                            {String.fromCharCode(65 + letterIdx)}
+                          </option>
+                        {/each}
+                      </select>
+                    {/if}
+                  </div>
+                {/each}
+              </div>
+            </div>
+
+            <!-- Plans (Right) -->
+            <div>
+              <p class="text-sm font-semibold text-gray-400 mb-3">Plan Assignments:</p>
+              <div class="space-y-2">
+                {#each modalPlans as plan, letterIdx}
+                  <div class="flex items-center gap-2 p-2 bg-base-200/30 rounded">
+                    <div class="badge badge-lg badge-primary w-10 flex justify-center">
+                      {String.fromCharCode(65 + letterIdx)}
+                    </div>
+                    <div class="flex-1">
+                      <p class="text-xs text-gray-300">{plan.displayName}</p>
+                    </div>
+                  </div>
+                {/each}
+              </div>
+            </div>
+          </div>
+
+          <!-- Notice -->
+          <div class="alert alert-info text-sm">
+            <span>Server restart required to apply changes</span>
+          </div>
+        </div>
+      {/if}
+
+      <div class="modal-action mt-6">
+        <button
+          class="btn btn-ghost"
+          on:click={() => showFixIssueModal = false}
+          disabled={modalSubmitting}
+        >
+          Cancel
+        </button>
+        {#if selectedIssue === 'planUpgrade'}
+          <button
+            class="btn btn-primary"
+            on:click={submitPlanUpdates}
+            disabled={modalSubmitting || modalServers.some(s => !s.isPending && !planAssignments[s.id])}
+          >
+            {modalSubmitting ? 'Updating...' : 'Apply Changes'}
+          </button>
+        {/if}
+      </div>
+    </div>
+    <div class="modal-backdrop" on:click={() => showFixIssueModal = false}></div>
+  </div>
+{/if}

--- a/observer/src/routes/(login)/billing/+page.svelte
+++ b/observer/src/routes/(login)/billing/+page.svelte
@@ -44,7 +44,7 @@
   }
 
   let showFixIssueModal = false;
-  let selectedIssue: 'planUpgrade' | 'resubscribedSlot' | 'paymentRecovered' | null = null;
+  let selectedIssue: 'planUpgrade' | 'paymentRecovered' | null = null;
   let modalPlans = [];
   let modalServers = [];
   let planAssignments: Record<string, string> = {};
@@ -176,15 +176,6 @@
 
     try {
       // Handle different issue types
-      if (selectedIssue === 'resubscribedSlot') {
-        // For re-subscribed slot issue, show a generic message
-        alert("Your request has been submitted to our support team. We'll review your account and reassign your server slot as soon as possible.", "success");
-        showFixIssueModal = false;
-        selectedIssue = null;
-        modalSubmitting = false;
-        return;
-      }
-
       if (selectedIssue === 'paymentRecovered') {
         // Validate that a server is selected
         if (!selectedExpiredServerId) {
@@ -468,20 +459,10 @@
               type="radio"
               name="subscription-issue"
               class="radio radio-sm"
-              value="resubscribedSlot"
-              bind:group={selectedIssue}
-            />
-            <span class="text-sm">Re-subscribed, can't use server slot</span>
-          </label>
-          <label class="flex items-center gap-3 p-2 rounded hover:bg-base-200/50 transition cursor-pointer">
-            <input
-              type="radio"
-              name="subscription-issue"
-              class="radio radio-sm"
               value="paymentRecovered"
               bind:group={selectedIssue}
             />
-            <span class="text-sm">My server expired due to payment issues, and I have resolved them</span>
+            <span class="text-sm">My server is expired but it shouldn't be</span>
           </label>
         </div>
       </div>
@@ -536,7 +517,7 @@
     <div class="modal-box max-w-3xl max-h-[80vh] overflow-y-auto">
       <div class="mb-4">
         <h3 class="font-bold text-lg">
-          {selectedIssue === 'planUpgrade' ? 'Update Server Plans' : selectedIssue === 'resubscribedSlot' ? 'Reassign Server Slot' : 'Recover Expired Server'}
+          {selectedIssue === 'planUpgrade' ? 'Update Server Plans' : 'Recover Expired Server'}
         </h3>
         {#if selectedIssue === 'planUpgrade'}
           <p class="text-sm text-gray-400 mt-1">Let's make sure your plans are allocated properly</p>
@@ -613,13 +594,6 @@
           <div class="alert alert-info text-sm">
             <span>Server restart required to apply changes</span>
           </div>
-        </div>
-      {:else if selectedIssue === 'resubscribedSlot'}
-        <div class="space-y-4">
-          <div class="alert alert-info">
-            <p class="text-sm">Our support team will review your account and reassign your server slot so you can start using your server again.</p>
-          </div>
-          <p class="text-sm text-gray-400">You'll receive an email update once your slot has been reassigned.</p>
         </div>
       {:else if selectedIssue === 'paymentRecovered'}
         <div class="space-y-4">

--- a/observer/src/routes/(login)/billing/+page.svelte
+++ b/observer/src/routes/(login)/billing/+page.svelte
@@ -44,22 +44,19 @@
   }
 
   let showFixIssueModal = false;
-  let selectedIssue: 'planUpgrade' | 'resubscribedSlot' | null = null;
+  let selectedIssue: 'planUpgrade' | 'resubscribedSlot' | 'paymentRecovered' | null = null;
   let modalPlans = [];
   let modalServers = [];
   let planAssignments: Record<string, string> = {};
   let modalLoading = false;
   let modalError = '';
   let modalSubmitting = false;
+  let expiredServers = [];
+  let selectedExpiredServerId = '';
 
-  async function openFixIssueModal() {
-    modalLoading = true;
-    modalError = '';
-    planAssignments = {};
-
+  async function loadExpiredServers() {
     try {
-      // Load current plans and servers
-      const response = await fetch(apiurl + "info/billing", {
+      const response = await fetch(apiurl + "support/listExpiredServers", {
         method: "GET",
         headers: {
           username: localStorage.getItem("accountEmail"),
@@ -69,33 +66,72 @@
 
       const data = await response.json();
 
-      // Process plans
-      const planCounts: Record<string, number> = {};
-      data.subscriptions.forEach((sub: any) => {
-        planCounts[sub.name] = (planCounts[sub.name] || 0) + 1;
-      });
+      if (data.success) {
+        expiredServers = data.expiredServers || [];
+        // Auto-select first expired server if available
+        if (expiredServers.length > 0) {
+          selectedExpiredServerId = expiredServers[0].id;
+        }
+      } else {
+        modalError = "Failed to load expired servers";
+      }
+    } catch (e) {
+      modalError = "Failed to load expired servers";
+      console.error(e);
+    }
+  }
 
-      modalPlans = Object.entries(planCounts).map(([name, count]) => ({
-        name,
-        count,
-        displayName: `${count}x ${name.charAt(0).toUpperCase() + name.slice(1)} Plan`
-      }));
+  async function openFixIssueModal() {
+    modalLoading = true;
+    modalError = '';
+    planAssignments = {};
+    expiredServers = [];
+    selectedExpiredServerId = '';
 
-      // Process servers - include all servers to show pending status
-      modalServers = data.servers.map((server: any) => {
-        const isPending = server.plan === "not created yet";
-        return {
-          id: server.id,
-          software: server.software,
-          version: server.version,
-          currentPlan: server.plan,
-          isPending
-        };
-      });
+    try {
+      // If paymentRecovered is selected, load expired servers
+      if (selectedIssue === 'paymentRecovered') {
+        await loadExpiredServers();
+      } else {
+        // For other issues, load current plans and servers
+        const response = await fetch(apiurl + "info/billing", {
+          method: "GET",
+          headers: {
+            username: localStorage.getItem("accountEmail"),
+            token: localStorage.getItem("token"),
+          },
+        });
+
+        const data = await response.json();
+
+        // Process plans
+        const planCounts: Record<string, number> = {};
+        data.subscriptions.forEach((sub: any) => {
+          planCounts[sub.name] = (planCounts[sub.name] || 0) + 1;
+        });
+
+        modalPlans = Object.entries(planCounts).map(([name, count]) => ({
+          name,
+          count,
+          displayName: `${count}x ${name.charAt(0).toUpperCase() + name.slice(1)} Plan`
+        }));
+
+        // Process servers - include all servers to show pending status
+        modalServers = data.servers.map((server: any) => {
+          const isPending = server.plan === "not created yet";
+          return {
+            id: server.id,
+            software: server.software,
+            version: server.version,
+            currentPlan: server.plan,
+            isPending
+          };
+        });
+      }
 
       showFixIssueModal = true;
     } catch (e) {
-      modalError = "Failed to load plans and servers";
+      modalError = "Failed to load data";
       console.error(e);
     }
 
@@ -128,6 +164,73 @@
       }
     } catch (e) {
       modalError = "Failed to update plans";
+      console.error(e);
+    }
+
+    modalSubmitting = false;
+  }
+
+  async function submitIssueRequest() {
+    modalSubmitting = true;
+    modalError = '';
+
+    try {
+      // Handle different issue types
+      if (selectedIssue === 'resubscribedSlot') {
+        // For re-subscribed slot issue, show a generic message
+        alert("Your request has been submitted to our support team. We'll review your account and reassign your server slot as soon as possible.", "success");
+        showFixIssueModal = false;
+        selectedIssue = null;
+        modalSubmitting = false;
+        return;
+      }
+
+      if (selectedIssue === 'paymentRecovered') {
+        // Validate that a server is selected
+        if (!selectedExpiredServerId) {
+          modalError = "Please select a server to recover";
+          modalSubmitting = false;
+          return;
+        }
+
+        // For payment recovery, call the server recovery endpoint
+        const response = await fetch(apiurl + "support/serverRecovery", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            username: localStorage.getItem("accountEmail"),
+            token: localStorage.getItem("token"),
+          },
+          body: JSON.stringify({
+            accountId: accountId,
+            targetServerId: selectedExpiredServerId
+          }),
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          modalError = data.message || "Failed to process your request";
+          modalSubmitting = false;
+          return;
+        }
+
+        if (data.success) {
+          if (data.recovered === false) {
+            // Slot freed but server gone
+            alert(data.message, "warning");
+          } else {
+            // Server restored
+            alert(`Great! ${data.message} Your server "${data.serverName}" is ready to use.`, "success");
+          }
+          showFixIssueModal = false;
+          selectedIssue = null;
+        } else {
+          modalError = data.message || "An error occurred";
+        }
+      }
+    } catch (e) {
+      modalError = "Failed to process your request";
       console.error(e);
     }
 
@@ -370,6 +473,16 @@
             />
             <span class="text-sm">Re-subscribed, can't use server slot</span>
           </label>
+          <label class="flex items-center gap-3 p-2 rounded hover:bg-base-200/50 transition cursor-pointer">
+            <input
+              type="radio"
+              name="subscription-issue"
+              class="radio radio-sm"
+              value="paymentRecovered"
+              bind:group={selectedIssue}
+            />
+            <span class="text-sm">My server expired due to payment issues, and I have resolved them</span>
+          </label>
         </div>
       </div>
     </div>
@@ -423,10 +536,12 @@
     <div class="modal-box max-w-3xl max-h-[80vh] overflow-y-auto">
       <div class="mb-4">
         <h3 class="font-bold text-lg">
-          {selectedIssue === 'planUpgrade' ? 'Update Server Plans' : 'Reassign Server Slot'}
+          {selectedIssue === 'planUpgrade' ? 'Update Server Plans' : selectedIssue === 'resubscribedSlot' ? 'Reassign Server Slot' : 'Recover Expired Server'}
         </h3>
         {#if selectedIssue === 'planUpgrade'}
           <p class="text-sm text-gray-400 mt-1">Let's make sure your plans are allocated properly</p>
+        {:else if selectedIssue === 'paymentRecovered'}
+          <p class="text-sm text-gray-400 mt-1">We'll help you restore your server after payment recovery</p>
         {/if}
       </div>
 
@@ -499,6 +614,41 @@
             <span>Server restart required to apply changes</span>
           </div>
         </div>
+      {:else if selectedIssue === 'resubscribedSlot'}
+        <div class="space-y-4">
+          <div class="alert alert-info">
+            <p class="text-sm">Our support team will review your account and reassign your server slot so you can start using your server again.</p>
+          </div>
+          <p class="text-sm text-gray-400">You'll receive an email update once your slot has been reassigned.</p>
+        </div>
+      {:else if selectedIssue === 'paymentRecovered'}
+        <div class="space-y-4">
+          {#if expiredServers.length > 0}
+            <div>
+              <label class="block text-sm font-semibold text-gray-400 mb-2">Select server to recover:</label>
+              <select
+                class="select select-bordered w-full"
+                bind:value={selectedExpiredServerId}
+              >
+                <option value="">-- Choose a server --</option>
+                {#each expiredServers as server}
+                  <option value={server.id}>
+                    Slot {server.id} - {server.software.charAt(0).toUpperCase() + server.software.slice(1)} {server.version}
+                  </option>
+                {/each}
+              </select>
+            </div>
+          {:else}
+            <div class="alert alert-warning">
+              <p class="text-sm">No expired servers found. All your servers are currently active.</p>
+            </div>
+          {/if}
+
+          <div class="alert alert-info">
+            <p class="text-sm">We'll check if your server can be recovered. If it's marked as expired but still exists, it will be restored automatically and you can use it immediately.</p>
+          </div>
+          <p class="text-sm text-gray-400">If your server was deleted past the grace period, you'll see a message with instructions on how to recover your data.</p>
+        </div>
       {/if}
 
       <div class="modal-action mt-6">
@@ -516,6 +666,14 @@
             disabled={modalSubmitting || modalServers.some(s => !s.isPending && !planAssignments[s.id])}
           >
             {modalSubmitting ? 'Updating...' : 'Apply Changes'}
+          </button>
+        {:else}
+          <button
+            class="btn btn-primary"
+            on:click={submitIssueRequest}
+            disabled={modalSubmitting || (selectedIssue === 'paymentRecovered' && !selectedExpiredServerId)}
+          >
+            {modalSubmitting ? 'Submitting...' : 'Submit Request'}
           </button>
         {/if}
       </div>

--- a/observer/src/routes/(login)/billing/+page.svelte
+++ b/observer/src/routes/(login)/billing/+page.svelte
@@ -2,7 +2,8 @@
   import { apiurl, customerPortalLink } from "$lib/scripts/req";
   import { t, locale, locales } from "$lib/scripts/i18n";
   import { browser } from "$app/environment";
-  import { ClipboardList, MessagesSquare, CreditCard, Server, CheckCircle, XCircle, AlertCircle, Clock, ExternalLink } from "lucide-svelte";
+  import { ClipboardList, MessagesSquare, CreditCard, Server, CheckCircle, XCircle, AlertCircle, Clock, ExternalLink, RefreshCw } from "lucide-svelte";
+  import { alert } from "$lib/scripts/utils";
 
   let servers = [];
   var email: string = "";
@@ -40,6 +41,32 @@
     if (browser) {
       localStorage.setItem("subscribed", "true");
     }
+  }
+
+  let syncing = false;
+
+  async function syncPlan() {
+    syncing = true;
+    try {
+      const res = await fetch(apiurl + "info/syncplan", {
+        method: "POST",
+        headers: {
+          username: localStorage.getItem("accountEmail"),
+          token: localStorage.getItem("token"),
+        },
+      });
+      const json = await res.json();
+      if (json.changed) {
+        alert("Plan updated — restart your server to apply the new RAM and storage allocation.", "success");
+      } else if (json.reason === "no_active_subscription") {
+        alert("No active subscription found. If you just subscribed, it may take a moment to activate.", "info");
+      } else {
+        alert("Your plan is already up to date.", "success");
+      }
+    } catch (e) {
+      alert("Failed to sync plan. Please try again.", "error");
+    }
+    syncing = false;
   }
 
   function getStatusColor(status: string) {
@@ -133,6 +160,14 @@
           {$t("button.newsubscribe")}
         {/if}
       </a>
+      <button
+        class="btn btn-outline gap-2"
+        on:click={syncPlan}
+        disabled={syncing}
+      >
+        <RefreshCw size="18" class="mr-1.5 {syncing ? 'animate-spin' : ''}" />
+        {syncing ? "Refreshing..." : "Refresh Plans"}
+      </button>
     </div>
 
     <!-- Two Column Layout: Subscriptions (Left) | Servers (Right) -->

--- a/observer/src/routes/(login)/billing/+page.svelte
+++ b/observer/src/routes/(login)/billing/+page.svelte
@@ -87,6 +87,7 @@
     planAssignments = {};
     expiredServers = [];
     selectedExpiredServerId = '';
+    showFixIssueModal = true;
 
     try {
       // If paymentRecovered is selected, load expired servers
@@ -102,12 +103,23 @@
           },
         });
 
+        if (!response.ok) {
+          throw new Error(`API error: ${response.status}`);
+        }
+
         const data = await response.json();
+
+        // Validate response structure
+        if (!data || !data.subscriptions || !data.servers) {
+          throw new Error("Invalid response format from API");
+        }
 
         // Process plans
         const planCounts: Record<string, number> = {};
         data.subscriptions.forEach((sub: any) => {
-          planCounts[sub.name] = (planCounts[sub.name] || 0) + 1;
+          if (sub.name) {
+            planCounts[sub.name] = (planCounts[sub.name] || 0) + 1;
+          }
         });
 
         modalPlans = Object.entries(planCounts).map(([name, count]) => ({
@@ -117,22 +129,27 @@
         }));
 
         // Process servers - include all servers to show pending status
-        modalServers = data.servers.map((server: any) => {
-          const isPending = server.plan === "not created yet";
-          return {
-            id: server.id,
-            software: server.software,
-            version: server.version,
-            currentPlan: server.plan,
-            isPending
-          };
-        });
-      }
+        modalServers = data.servers
+          .filter((server: any) => server.id !== undefined && server.id !== null)
+          .map((server: any) => {
+            const isPending = server.plan === "not created yet";
+            return {
+              id: server.id,
+              software: server.software || "Unknown",
+              version: server.version || "Unknown",
+              currentPlan: server.plan,
+              isPending
+            };
+          });
 
-      showFixIssueModal = true;
+        if (modalServers.length === 0) {
+          throw new Error("No valid servers available");
+        }
+      }
     } catch (e) {
-      modalError = "Failed to load data";
-      console.error(e);
+      const errorMsg = e instanceof Error ? e.message : String(e);
+      modalError = `Failed to load data: ${errorMsg}`;
+      console.error("openFixIssueModal error:", e);
     }
 
     modalLoading = false;

--- a/observer/src/routes/(login)/server/[slug]/backups/Backups.svelte
+++ b/observer/src/routes/(login)/server/[slug]/backups/Backups.svelte
@@ -11,6 +11,10 @@
   let isBackingUp = false;
   let backupProgress = null;
   let progressPoll = null;
+  let isRestoring = false;
+  let restoreError = '';
+  let restoreSuccess = false;
+  let restoringBackupId = null;
 
   function loadBackups() {
     if (browser) {
@@ -137,6 +141,51 @@
       })
       .catch((error) => {
         console.error("Error downloading backup:", error);
+      });
+  }
+
+  function restore(timestamp) {
+    isRestoring = true;
+    restoringBackupId = timestamp;
+    restoreError = '';
+    restoreSuccess = false;
+
+    fetch(
+      apiurl +
+        "server/" +
+        localStorage.getItem("serverID") +
+        "/backup/" +
+        timestamp +
+        "/restore",
+      {
+        method: "POST",
+        headers: {
+          token: localStorage.getItem("token"),
+          username: localStorage.getItem("accountEmail"),
+        },
+      }
+    )
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.success) {
+          restoreSuccess = true;
+          setTimeout(() => {
+            isRestoring = false;
+            restoringBackupId = null;
+            // Reload backups after restore
+            loadBackups();
+          }, 3000);
+        } else {
+          restoreError = data.message || "Failed to restore backup";
+          isRestoring = false;
+          restoringBackupId = null;
+        }
+      })
+      .catch((error) => {
+        console.error("Error restoring backup:", error);
+        restoreError = "Error restoring backup: " + error.message;
+        isRestoring = false;
+        restoringBackupId = null;
       });
   }
 </script>
@@ -288,6 +337,17 @@
                     <Download class="mr-1.5" size={16} />
                     <span class="hidden sm:inline">Download</span>
                   </a>
+                  <button
+                    on:click={() => restore(backup.timestamp)}
+                    disabled={isRestoring}
+                    class="btn btn-sm btn-ghost gap-1 hover:btn-warning"
+                    title="Restore this backup"
+                  >
+                    <svg class="mr-1.5 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    <span class="hidden sm:inline">Restore</span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -301,7 +361,71 @@
   <div class="mt-5 pt-4 border-t border-base-100 text-xs text-gray-400">
     <p class="flex items-center gap-1.5">
       <InfoIcon size={14} />
-      Automatic backups run based on your scheduler, by default every 6 hours. 
+      Automatic backups run based on your scheduler, by default every 6 hours.
     </p>
   </div>
 </div>
+
+<!-- Restore Modal -->
+{#if isRestoring || restoreSuccess || restoreError}
+  <div class="modal modal-open">
+    <div class="modal-box">
+      <h3 class="font-bold text-lg">
+        {#if isRestoring}
+          Restoring Backup...
+        {:else if restoreSuccess}
+          ✅ Backup Restored
+        {:else}
+          ❌ Restore Failed
+        {/if}
+      </h3>
+
+      {#if isRestoring}
+        <div class="py-6 text-center">
+          <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg"></span>
+            <p class="text-sm text-gray-400">
+              Restoring your world... The server will restart automatically.
+            </p>
+          </div>
+        </div>
+      {:else if restoreSuccess}
+        <div class="py-4">
+          <p class="text-sm text-gray-300 mb-4">
+            Your backup has been successfully restored! The current world has been moved to a backup folder and your server will restart.
+          </p>
+          <div class="alert alert-info text-sm">
+            <span>The server is restarting now. You'll be back online shortly.</span>
+          </div>
+        </div>
+        <div class="modal-action">
+          <button
+            class="btn"
+            on:click={() => {
+              restoreSuccess = false;
+            }}
+          >
+            Close
+          </button>
+        </div>
+      {:else if restoreError}
+        <div class="py-4">
+          <p class="text-sm text-gray-300 mb-4">
+            {restoreError}
+          </p>
+        </div>
+        <div class="modal-action">
+          <button
+            class="btn"
+            on:click={() => {
+              restoreError = '';
+            }}
+          >
+            Close
+          </button>
+        </div>
+      {/if}
+    </div>
+    <div class="modal-backdrop" />
+  </div>
+{/if}

--- a/quartz/routes/info.js
+++ b/quartz/routes/info.js
@@ -533,4 +533,43 @@ router.get("/snapshot", (req, res) => {
     res.json(snapshotHistory);
 });
 
+router.post(`/syncplan`, function (req, res) {
+  if (mode !== "provider") return res.status(400).json({ msg: "Not in provider mode." });
+  let email = req.headers.username;
+  let token = req.headers.token;
+  let account = readJSON(`accounts/${email}.json`);
+  if (!account || token !== account.token) return res.status(401).json({ msg: "Invalid credentials." });
+
+  stripe.customers.list({ limit: 100, email: account.email }, function (err, customers) {
+    if (err || customers.data.length === 0) return res.status(200).json({ changed: false });
+    let cid = customers.data[0].id;
+
+    stripe.subscriptions.list({ customer: cid, limit: 10, status: "active" }, function (err, subs) {
+      if (err) return res.status(200).json({ changed: false, reason: "error" });
+      if (subs.data.length === 0) return res.status(200).json({ changed: false, reason: "no_active_subscription" });
+
+      // Use the most recent active subscription's product ID
+      let currentProductId = subs.data[0].items.data[0].plan.product;
+
+      let changed = [];
+      for (let serverId of account.servers) {
+        let serverPath = `servers/${serverId}/server.json`;
+        if (!fs.existsSync(serverPath)) continue;
+        let server = readJSON(serverPath);
+        if (server.productID !== currentProductId) {
+          server.productID = currentProductId;
+          writeJSON(serverPath, server);
+          changed.push(serverId);
+        }
+      }
+
+      if (changed.length > 0) {
+        res.status(200).json({ changed: true, servers: changed });
+      } else {
+        res.status(200).json({ changed: false });
+      }
+    });
+  });
+});
+
 module.exports = router;

--- a/quartz/routes/info.js
+++ b/quartz/routes/info.js
@@ -64,6 +64,7 @@ router.get(`/servers`, function (req, res) {
         let hasValidSubscription = true;
         let parsedSuccesfully = false;
                 let resetDate = -1;
+                let subscriptionCause = "unknown";
         if (mode === "provider") {
           hasValidSubscription = false;
                   let subscriptionsJson = readJSON(`logs/subscriptions.json`);
@@ -71,11 +72,11 @@ router.get(`/servers`, function (req, res) {
 
 try {
         for (let sub of subscriptionsJson) {
-        
+
 
             if (sub.owner == req.headers.username + ".json" && sub.subscriptions != undefined) {
               parsedSuccesfully = true;
-                        
+
             for (let item of sub.subscriptions) {
 
               if (item.start_date > latestStartDate) {
@@ -83,14 +84,21 @@ try {
               }
               if (item.status == "active") {
                 hasValidSubscription = true;
-          
+
               } else {
-         
+
                             //add 7 days to the current period end if the subscription is canceled
             resetDate = parseInt(item.current_period_end) + 604800;
+            if (item.status === "past_due" || item.status === "unpaid") {
+              subscriptionCause = "payment_failed";
+            } else if (item.status === "canceled") {
+              subscriptionCause = "canceled";
+            } else {
+              subscriptionCause = item.status || "unknown";
+            }
               }
             }
-          } 
+          }
       
           
         }
@@ -100,7 +108,7 @@ try {
       }
         console.log("hasValidSubscription: " + hasValidSubscription);
         //if the start date is from the past 24 hours, set hasValidSubscription to true
-        if (latestStartDate > 0 && latestStartDate < Date.now() - 86400000) {
+        if (latestStartDate > 0 && latestStartDate > Date.now() - 86400000) {
           hasValidSubscription = true;
         }
       }
@@ -109,7 +117,7 @@ try {
         if (account.servers[i].includes(":freed")) {
           account.servers[i] = account.servers[i].replace(":freed", "") + ":no valid subscription:" + -1;
         } else if (!hasValidSubscription && parsedSuccesfully) {
-          account.servers[i] = account.servers[i] + ":no valid subscription:" + resetDate;
+          account.servers[i] = account.servers[i] + ":no valid subscription:" + resetDate + ":" + subscriptionCause;
         } else if (fs.existsSync(`servers/${account.servers[i]}/server.json`)) {
         account.servers[i] = readJSON(
           `servers/${account.servers[i]}/server.json`

--- a/quartz/routes/info.js
+++ b/quartz/routes/info.js
@@ -56,6 +56,7 @@ router.get(`/servers`, function (req, res) {
 
 
     for (let i in account.servers) {
+                const serverId = account.servers[i];
 
 
   
@@ -118,7 +119,8 @@ try {
           account.servers[i] = account.servers[i].replace(":freed", "") + ":no valid subscription:" + -1;
         } else if (!hasValidSubscription && parsedSuccesfully) {
           account.servers[i] = account.servers[i] + ":no valid subscription:" + resetDate + ":" + subscriptionCause;
-        } else if (fs.existsSync(`servers/${account.servers[i]}/server.json`)) {
+        } else if (fs.existsSync(`servers/${serverId}/server.json`)) {
+                  let serverData = readJSON(`servers/${serverId}/server.json`);
         account.servers[i] = readJSON(
           `servers/${account.servers[i]}/server.json`
         );
@@ -197,13 +199,25 @@ router.get(`/billing`, function (req, res) {
               }
               let serversArray = [];
               for (let i in account.servers) {
-                if (fs.existsSync(`servers/${account.servers[i]}/server.json`)) {
+                const serverId = account.servers[i];
+                if (fs.existsSync(`servers/${serverId}/server.json`)) {
+                  let serverData = readJSON(`servers/${serverId}/server.json`);
                   let planName = "basic";
-                  if (account.servers[i].productID == config.plus) planName = "plus"; 
-                  if (account.servers[i].productID == config.premium) planName = "premium";
-                  serversArray.push(account.servers[i].id + ":" + planName);
+                  if (serverData.productID == config.plus) planName = "plus";
+                  if (serverData.productID == config.premium) planName = "premium";
+                  serversArray.push({
+                    id: serverId,
+                    software: serverData.software || "Unknown",
+                    version: serverData.version || "Unknown",
+                    plan: planName
+                  });
                 } else {
-                  serversArray.push(account.servers[i] + ":undefined");
+                  serversArray.push({
+                    id: serverId,
+                    software: "Unknown",
+                    version: "Unknown",
+                    plan: "not created yet"
+                  });
                 }
               }
               res.status(200).json({
@@ -533,42 +547,45 @@ router.get("/snapshot", (req, res) => {
     res.json(snapshotHistory);
 });
 
-router.post(`/syncplan`, function (req, res) {
+router.post(`/updatePlans`, function (req, res) {
   if (mode !== "provider") return res.status(400).json({ msg: "Not in provider mode." });
   let email = req.headers.username;
   let token = req.headers.token;
   let account = readJSON(`accounts/${email}.json`);
   if (!account || token !== account.token) return res.status(401).json({ msg: "Invalid credentials." });
 
-  stripe.customers.list({ limit: 100, email: account.email }, function (err, customers) {
-    if (err || customers.data.length === 0) return res.status(200).json({ changed: false });
-    let cid = customers.data[0].id;
+  // req.body should contain { planAssignments: { serverId: planName, serverId: planName, ... } }
+  let planAssignments = req.body.planAssignments || {};
+  let updated = [];
+  let errors = [];
 
-    stripe.subscriptions.list({ customer: cid, limit: 10, status: "active" }, function (err, subs) {
-      if (err) return res.status(200).json({ changed: false, reason: "error" });
-      if (subs.data.length === 0) return res.status(200).json({ changed: false, reason: "no_active_subscription" });
+  for (let serverId in planAssignments) {
+    let serverPath = `servers/${serverId}/server.json`;
+    if (!fs.existsSync(serverPath)) {
+      errors.push(`Server ${serverId} not found`);
+      continue;
+    }
 
-      // Use the most recent active subscription's product ID
-      let currentProductId = subs.data[0].items.data[0].plan.product;
+    let planName = planAssignments[serverId];
+    // Convert plan name to product ID
+    let productId = config.basic; // default
+    if (planName === "plus") productId = config.plus;
+    if (planName === "premium") productId = config.premium;
 
-      let changed = [];
-      for (let serverId of account.servers) {
-        let serverPath = `servers/${serverId}/server.json`;
-        if (!fs.existsSync(serverPath)) continue;
-        let server = readJSON(serverPath);
-        if (server.productID !== currentProductId) {
-          server.productID = currentProductId;
-          writeJSON(serverPath, server);
-          changed.push(serverId);
-        }
-      }
+    let server = readJSON(serverPath);
+    server.productID = productId;
+    try {
+      writeJSON(serverPath, server);
+      updated.push(serverId);
+    } catch (e) {
+      errors.push(`Failed to update server ${serverId}: ${e}`);
+    }
+  }
 
-      if (changed.length > 0) {
-        res.status(200).json({ changed: true, servers: changed });
-      } else {
-        res.status(200).json({ changed: false });
-      }
-    });
+  res.status(200).json({
+    updated: updated,
+    errors: errors,
+    message: "Server restart required to apply changes"
   });
 });
 

--- a/quartz/routes/server/index.js
+++ b/quartz/routes/server/index.js
@@ -1741,17 +1741,12 @@ router.post("/:id/backup/:timestamp/restore", async function (req, res) {
 
     // Restart the server
     try {
-      const { spawn } = require("child_process");
       const serverScript = require("../../scripts/mc.js");
 
-      // Stop the server first
-      await serverScript.stopServer(req.params.id);
-
-      // Wait a bit for clean shutdown
-      await new Promise(resolve => setTimeout(resolve, 2000));
-
-      // Start the server
-      await serverScript.startServer(req.params.id);
+      // Stop the server and restart it
+      serverScript.stopAsync(req.params.id, () => {
+        serverScript.run(req.params.id, undefined, undefined, undefined, undefined, email, false);
+      });
 
       res.status(200).json({
         success: true,

--- a/quartz/routes/server/index.js
+++ b/quartz/routes/server/index.js
@@ -1645,6 +1645,131 @@ router.get("/:id/backup/:timestamp", function (req, res) {
   }
 });
 
+// Restore backup endpoint
+router.post("/:id/backup/:timestamp/restore", async function (req, res) {
+  let email = req.headers.username;
+  let token = req.headers.token;
+  let account = readJSON("accounts/" + email + ".json");
+
+  // Check authentication
+  if (!utils.hasAccess(token, account, req.params.id)) {
+    return res.status(401).json({ success: false, message: "Unauthorized" });
+  }
+
+  const backupPath = `backups/${req.params.id}/${req.params.timestamp}.zip`;
+  const serverPath = `servers/${req.params.id}`;
+  const worldPath = `${serverPath}/world`;
+
+  try {
+    // Check if backup exists
+    if (!fs.existsSync(backupPath)) {
+      return res.status(404).json({ success: false, message: "Backup not found" });
+    }
+
+    // Create temp directory for extraction
+    const tempExtractPath = `${serverPath}/temp_restore_${Date.now()}`;
+    if (!fs.existsSync(tempExtractPath)) {
+      fs.mkdirSync(tempExtractPath, { recursive: true });
+    }
+
+    // Extract backup using unzip command
+    const { spawn } = require("child_process");
+
+    const unzip = spawn("unzip", ["-q", backupPath, "-d", tempExtractPath]);
+
+    await new Promise((resolve, reject) => {
+      unzip.on("close", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Unzip failed with code ${code}`));
+        }
+      });
+      unzip.on("error", reject);
+    });
+
+    // Find the world folder in the extracted backup
+    // The zip contains servers/{id}/world, so we need to search for the world folder
+    let extractedWorldPath = null;
+
+    function findWorldFolder(dir) {
+      const items = fs.readdirSync(dir);
+      for (const item of items) {
+        const itemPath = path.join(dir, item);
+        const stat = fs.statSync(itemPath);
+
+        if (item === "world" && stat.isDirectory()) {
+          return itemPath;
+        }
+
+        if (stat.isDirectory()) {
+          const found = findWorldFolder(itemPath);
+          if (found) return found;
+        }
+      }
+      return null;
+    }
+
+    extractedWorldPath = findWorldFolder(tempExtractPath);
+
+    if (!extractedWorldPath) {
+      // Clean up temp directory
+      fs.rmSync(tempExtractPath, { recursive: true });
+      return res.status(400).json({ success: false, message: "Invalid backup file structure - world folder not found" });
+    }
+
+    // Backup current world by renaming it
+    if (fs.existsSync(worldPath)) {
+      let oldWorldPath = `${serverPath}/world_old`;
+      let counter = 2;
+
+      while (fs.existsSync(oldWorldPath)) {
+        oldWorldPath = `${serverPath}/world_old_${counter}`;
+        counter++;
+      }
+
+      fs.renameSync(worldPath, oldWorldPath);
+      console.log(`Backed up current world to ${oldWorldPath}`);
+    }
+
+    // Move extracted world to the server path
+    fs.renameSync(extractedWorldPath, worldPath);
+    console.log(`Restored world from backup at ${req.params.timestamp}`);
+
+    // Clean up temp directory
+    fs.rmSync(tempExtractPath, { recursive: true });
+
+    // Restart the server
+    try {
+      const { spawn } = require("child_process");
+      const serverScript = require("../../scripts/mc.js");
+
+      // Stop the server first
+      await serverScript.stopServer(req.params.id);
+
+      // Wait a bit for clean shutdown
+      await new Promise(resolve => setTimeout(resolve, 2000));
+
+      // Start the server
+      await serverScript.startServer(req.params.id);
+
+      res.status(200).json({
+        success: true,
+        message: "Backup restored successfully. Server is restarting."
+      });
+    } catch (restartError) {
+      console.error("Error restarting server during restore:", restartError);
+      res.status(200).json({
+        success: true,
+        message: "Backup restored successfully. Please restart the server manually."
+      });
+    }
+  } catch (error) {
+    console.error("Error restoring backup:", error);
+    res.status(500).json({ success: false, message: "Error restoring backup: " + error.message });
+  }
+});
+
 router.get("/:id/players", function (req, res) {
   let email = req.headers.username;
   let token = req.headers.token;

--- a/quartz/routes/support.js
+++ b/quartz/routes/support.js
@@ -40,9 +40,13 @@ router.get("/listExpiredServers", async (req, res) => {
         try {
           if (fs.existsSync("trashbin")) {
             const trashbinItems = fs.readdirSync("trashbin");
+            // Extract email owner from account email (without .json extension)
+            const emailOwner = email.includes(".json") ? email.replace(".json", "") : email;
+
             for (const item of trashbinItems) {
-              // Trashbin format: "serverId-email"
-              if (item.startsWith(serverId + "-")) {
+              // Trashbin format: "serverId-emailOwner"
+              // Only load if it matches both the server ID AND the correct email owner
+              if (item === `${serverId}-${emailOwner}`) {
                 const trashPath = `trashbin/${item}`;
                 if (fs.existsSync(`${trashPath}/server.json`)) {
                   serverData = readJSON(`${trashPath}/server.json`);
@@ -216,10 +220,25 @@ function handleServerRecovery(res, email, targetServerId, verified) {
         try {
           if (fs.existsSync("trashbin")) {
             const trashbinItems = fs.readdirSync("trashbin");
+            // Extract email owner from account email (without .json extension)
+            const emailOwner = email.includes(".json") ? email.replace(".json", "") : email;
+
             for (const item of trashbinItems) {
-              if (item.startsWith(serverId + "-")) {
+              // Trashbin format: "serverId-emailOwner"
+              // Only restore if it matches both the server ID AND the correct email owner
+              if (item === `${serverId}-${emailOwner}`) {
                 const trashPath = `trashbin/${item}`;
                 if (fs.existsSync(`${trashPath}/server.json`)) {
+                  // Check if slot is already taken by another user
+                  if (fs.existsSync(`servers/${serverId}`)) {
+                    // Slot is taken, cannot restore
+                    return res.status(409).json({
+                      success: false,
+                      message: "This server slot has been claimed by another user. Please contact support to resolve this issue.",
+                      recovered: false
+                    });
+                  }
+
                   recoveredServer = readJSON(`${trashPath}/server.json`);
                   recoveredServerId = serverId;
                   serverLocation = "trashbin";

--- a/quartz/routes/support.js
+++ b/quartz/routes/support.js
@@ -144,8 +144,12 @@ router.post("/serverRecovery", async (req, res) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
-    // Verify server belongs to user
-    if (!account.servers.includes(targetServerId)) {
+    // Verify server belongs to user (handle both regular and :freed entries)
+    const serverExists = account.servers.some(s => {
+      const serverId = typeof s === "string" ? s.replace(":freed", "") : s;
+      return serverId === targetServerId;
+    });
+    if (!serverExists) {
       return res.status(403).json({ success: false, message: "Server not found" });
     }
 
@@ -182,58 +186,93 @@ router.post("/serverRecovery", async (req, res) => {
   }
 });
 
-function handleServerRecovery(res, email, accountId, verified) {
+function handleServerRecovery(res, email, targetServerId, verified) {
   try {
     if (!verified) {
       return res.status(403).json({ success: false, message: "Verification failed" });
     }
 
     const account = readJSON(`accounts/${email}.json`);
-
-    // Find the server - look for most recently expired/unmarked server
     let recoveredServer = null;
     let recoveredServerId = null;
+    let serverLocation = null; // "servers" or "trashbin"
 
-    // Check all servers in account
-    for (const serverId of account.servers) {
-      const serverPath = `servers/${serverId}`;
+    // Find the server to recover
+    for (let serverEntry of account.servers) {
+      let serverId = serverEntry;
 
-      // Check if server directory exists
-      if (fs.existsSync(serverPath)) {
-        // Check if server.json exists
-        if (fs.existsSync(`${serverPath}/server.json`)) {
-          const server = readJSON(`${serverPath}/server.json`);
+      // Handle :freed flag
+      if (typeof serverEntry === "string" && serverEntry.includes(":freed")) {
+        serverId = serverEntry.replace(":freed", "");
+      }
 
-          // Check if server is marked as expired
-          if (server.expired || server.markedExpired) {
-            // Server exists but is marked expired - restore it
-            recoveredServer = server;
-            recoveredServerId = serverId;
-            break; // Recover the first expired one found
+      // Check if this is the server we're trying to recover
+      if (serverId !== targetServerId) {
+        continue;
+      }
+
+      // Check if server is in trashbin (has :freed flag)
+      if (typeof serverEntry === "string" && serverEntry.includes(":freed")) {
+        try {
+          if (fs.existsSync("trashbin")) {
+            const trashbinItems = fs.readdirSync("trashbin");
+            for (const item of trashbinItems) {
+              if (item.startsWith(serverId + "-")) {
+                const trashPath = `trashbin/${item}`;
+                if (fs.existsSync(`${trashPath}/server.json`)) {
+                  recoveredServer = readJSON(`${trashPath}/server.json`);
+                  recoveredServerId = serverId;
+                  serverLocation = "trashbin";
+                  // Move server back from trashbin to servers/
+                  fs.renameSync(trashPath, `servers/${serverId}`);
+                  // Remove :freed from account.servers
+                  account.servers = account.servers.map(s =>
+                    typeof s === "string" && s.includes(":freed") && s.startsWith(serverId) ? serverId : s
+                  );
+                  writeJSON(`accounts/${email}.json`, account);
+                  break;
+                }
+              }
+            }
           }
+        } catch (e) {
+          console.error("Error recovering server from trashbin:", e);
+        }
+      } else {
+        // Check if server is in servers directory
+        if (fs.existsSync(`servers/${serverId}/server.json`)) {
+          recoveredServer = readJSON(`servers/${serverId}/server.json`);
+          recoveredServerId = serverId;
+          serverLocation = "servers";
+          break;
         }
       }
+
+      if (recoveredServer) break;
     }
 
     if (recoveredServer) {
-      // Restore the server
-      recoveredServer.expired = false;
-      recoveredServer.markedExpired = false;
+      // If server was in servers/ and marked with flags, clear them
+      if (serverLocation === "servers") {
+        recoveredServer.expired = false;
+        recoveredServer.markedExpired = false;
+      }
       recoveredServer.restoredDate = Date.now();
 
       writeJSON(`servers/${recoveredServerId}/server.json`, recoveredServer);
 
       // Log recovery
-      console.log(`Server ${recoveredServerId} recovered for account ${email}`);
+      console.log(`Server ${recoveredServerId} recovered for account ${email} from ${serverLocation}`);
 
       return res.status(200).json({
         success: true,
         message: "Your server has been restored! You can now start using it again.",
         serverId: recoveredServerId,
-        serverName: recoveredServer.serverName || `Server ${recoveredServerId}`
+        serverName: recoveredServer.serverName || `Server ${recoveredServerId}`,
+        recovered: true
       });
     } else {
-      // Server not found in servers directory - must be deleted/trashed
+      // Server not found - may have been permanently deleted
       return res.status(200).json({
         success: true,
         message: "Your slot has been freed up. You have gone past the grace period, but you may still be able to recover your data. Please contact support for assistance.",

--- a/quartz/routes/support.js
+++ b/quartz/routes/support.js
@@ -26,52 +26,88 @@ router.get("/listExpiredServers", async (req, res) => {
     const expiredServers = [];
 
     // Check all servers in account
-    for (const serverId of account.servers) {
-      const serverPath = `servers/${serverId}`;
+    for (let serverEntry of account.servers) {
+      let serverId = serverEntry;
       let isExpired = false;
+      let serverData = null;
 
-      // Check if server is marked as expired in server.json
-      if (fs.existsSync(serverPath) && fs.existsSync(`${serverPath}/server.json`)) {
-        const server = readJSON(`${serverPath}/server.json`);
+      // Check if server entry has `:freed` flag (moved to trashbin)
+      if (typeof serverEntry === "string" && serverEntry.includes(":freed")) {
+        serverId = serverEntry.replace(":freed", "");
+        isExpired = true;
 
-        if (server.expired || server.markedExpired) {
-          isExpired = true;
-        }
-
-        // Also check subscription status (same logic as /servers endpoint)
-        if (!isExpired && mode === "provider") {
-          let hasValidSubscription = false;
-          try {
-            const subscriptionsJson = readJSON(`logs/subscriptions.json`);
-
-            for (let sub of subscriptionsJson) {
-              if (sub.owner == email + ".json" && sub.subscriptions != undefined) {
-                for (let item of sub.subscriptions) {
-                  if (item.status == "active") {
-                    hasValidSubscription = true;
-                    break;
-                  }
+        // Try to find server data in trashbin
+        try {
+          if (fs.existsSync("trashbin")) {
+            const trashbinItems = fs.readdirSync("trashbin");
+            for (const item of trashbinItems) {
+              // Trashbin format: "serverId-email"
+              if (item.startsWith(serverId + "-")) {
+                const trashPath = `trashbin/${item}`;
+                if (fs.existsSync(`${trashPath}/server.json`)) {
+                  serverData = readJSON(`${trashPath}/server.json`);
+                  break;
                 }
               }
-              if (hasValidSubscription) break;
             }
-          } catch (e) {
-            console.error("Error checking subscription status:", e);
           }
+        } catch (e) {
+          console.error("Error reading trashbin:", e);
+        }
+      } else {
+        // Check if server exists in servers directory
+        if (fs.existsSync(`servers/${serverId}/server.json`)) {
+          serverData = readJSON(`servers/${serverId}/server.json`);
 
-          if (!hasValidSubscription) {
-            isExpired = true;
+          // Check subscription status (same logic as /servers endpoint)
+          if (mode === "provider") {
+            let hasValidSubscription = false;
+            let latestStartDate = 0;
+
+            try {
+              const subscriptionsJson = readJSON(`logs/subscriptions.json`);
+
+              for (let sub of subscriptionsJson) {
+                if (sub.owner == email + ".json" && sub.subscriptions != undefined) {
+                  for (let item of sub.subscriptions) {
+                    if (item.start_date > latestStartDate) {
+                      latestStartDate = item.start_date;
+                    }
+                    if (item.status == "active") {
+                      hasValidSubscription = true;
+                      break;
+                    }
+                  }
+                }
+                if (hasValidSubscription) break;
+              }
+
+              // Check if recent subscription started (within 24 hours)
+              if (latestStartDate > 0 && latestStartDate > Date.now() - 86400000) {
+                hasValidSubscription = true;
+              }
+
+              if (!hasValidSubscription) {
+                isExpired = true;
+              }
+            } catch (e) {
+              console.error("Error checking subscription status:", e);
+            }
           }
         }
+      }
 
-        if (isExpired) {
-          expiredServers.push({
-            id: serverId,
-            name: server.serverName || `Server ${serverId}`,
-            software: server.software || "Unknown",
-            version: server.version || "Unknown"
-          });
-        }
+      // Add expired server to list
+      if (isExpired) {
+        const software = serverData?.software || "Unknown";
+        const version = serverData?.version || "Unknown";
+
+        expiredServers.push({
+          id: serverId,
+          name: serverData?.serverName || `Server ${serverId}`,
+          software: software,
+          version: version
+        });
       }
     }
 

--- a/quartz/routes/support.js
+++ b/quartz/routes/support.js
@@ -28,12 +28,43 @@ router.get("/listExpiredServers", async (req, res) => {
     // Check all servers in account
     for (const serverId of account.servers) {
       const serverPath = `servers/${serverId}`;
+      let isExpired = false;
 
+      // Check if server is marked as expired in server.json
       if (fs.existsSync(serverPath) && fs.existsSync(`${serverPath}/server.json`)) {
         const server = readJSON(`${serverPath}/server.json`);
 
-        // Check if server is marked as expired
         if (server.expired || server.markedExpired) {
+          isExpired = true;
+        }
+
+        // Also check subscription status (same logic as /servers endpoint)
+        if (!isExpired && mode === "provider") {
+          let hasValidSubscription = false;
+          try {
+            const subscriptionsJson = readJSON(`logs/subscriptions.json`);
+
+            for (let sub of subscriptionsJson) {
+              if (sub.owner == email + ".json" && sub.subscriptions != undefined) {
+                for (let item of sub.subscriptions) {
+                  if (item.status == "active") {
+                    hasValidSubscription = true;
+                    break;
+                  }
+                }
+              }
+              if (hasValidSubscription) break;
+            }
+          } catch (e) {
+            console.error("Error checking subscription status:", e);
+          }
+
+          if (!hasValidSubscription) {
+            isExpired = true;
+          }
+        }
+
+        if (isExpired) {
           expiredServers.push({
             id: serverId,
             name: server.serverName || `Server ${serverId}`,

--- a/quartz/routes/support.js
+++ b/quartz/routes/support.js
@@ -1,0 +1,182 @@
+const express = require("express");
+const router = express.Router();
+const fs = require("fs");
+const config = require("../scripts/utils.js").getConfig();
+const readJSON = require("../scripts/utils.js").readJSON;
+const writeJSON = require("../scripts/utils.js").writeJSON;
+const stripeKey = config.stripeKey;
+const stripe = require("stripe")(stripeKey);
+const mode = config.mode;
+
+// List expired servers for recovery selection
+router.get("/listExpiredServers", async (req, res) => {
+  try {
+    const email = req.headers.username;
+    const token = req.headers.token;
+
+    if (!email || !fs.existsSync(`accounts/${email}.json`)) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    const account = readJSON(`accounts/${email}.json`);
+    if (token !== account.token) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    const expiredServers = [];
+
+    // Check all servers in account
+    for (const serverId of account.servers) {
+      const serverPath = `servers/${serverId}`;
+
+      if (fs.existsSync(serverPath) && fs.existsSync(`${serverPath}/server.json`)) {
+        const server = readJSON(`${serverPath}/server.json`);
+
+        // Check if server is marked as expired
+        if (server.expired || server.markedExpired) {
+          expiredServers.push({
+            id: serverId,
+            name: server.serverName || `Server ${serverId}`,
+            software: server.software || "Unknown",
+            version: server.version || "Unknown"
+          });
+        }
+      }
+    }
+
+    res.status(200).json({
+      success: true,
+      expiredServers: expiredServers
+    });
+  } catch (error) {
+    console.error("List expired servers error:", error);
+    res.status(500).json({ success: false, message: "An error occurred" });
+  }
+});
+
+// Recover specific expired server after payment issues resolved
+router.post("/serverRecovery", async (req, res) => {
+  try {
+    const email = req.headers.username;
+    const token = req.headers.token;
+    const accountId = req.body.accountId;
+    const targetServerId = req.body.targetServerId; // Which server to recover
+
+    if (mode === "solo") {
+      // Solo mode - always allow
+      return handleServerRecovery(res, email, targetServerId, true);
+    }
+
+    // Get account and verify token
+    if (!email || !fs.existsSync(`accounts/${email}.json`)) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    const account = readJSON(`accounts/${email}.json`);
+    if (token !== account.token) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    // Verify server belongs to user
+    if (!account.servers.includes(targetServerId)) {
+      return res.status(403).json({ success: false, message: "Server not found" });
+    }
+
+    // Silent check: verify user has at least one valid subscription
+    try {
+      const subscriptions = await stripe.subscriptions.list({
+        customer: account.stripeCustomerId,
+        limit: 100
+      });
+
+      // Check if user has at least one active or past_due subscription
+      const hasValidSubscription = subscriptions.data.some(sub =>
+        sub.status === "active" || sub.status === "past_due"
+      );
+
+      if (!hasValidSubscription) {
+        // User doesn't have valid subscription - don't process
+        return res.status(403).json({
+          success: false,
+          message: "You must have an active subscription to use this feature"
+        });
+      }
+
+      // User has valid subscription - proceed with recovery
+      return handleServerRecovery(res, email, targetServerId, true);
+    } catch (stripeError) {
+      console.error("Stripe check error:", stripeError);
+      // If Stripe check fails, still allow recovery attempt
+      return handleServerRecovery(res, email, targetServerId, true);
+    }
+  } catch (error) {
+    console.error("Server recovery error:", error);
+    res.status(500).json({ success: false, message: "An error occurred" });
+  }
+});
+
+function handleServerRecovery(res, email, accountId, verified) {
+  try {
+    if (!verified) {
+      return res.status(403).json({ success: false, message: "Verification failed" });
+    }
+
+    const account = readJSON(`accounts/${email}.json`);
+
+    // Find the server - look for most recently expired/unmarked server
+    let recoveredServer = null;
+    let recoveredServerId = null;
+
+    // Check all servers in account
+    for (const serverId of account.servers) {
+      const serverPath = `servers/${serverId}`;
+
+      // Check if server directory exists
+      if (fs.existsSync(serverPath)) {
+        // Check if server.json exists
+        if (fs.existsSync(`${serverPath}/server.json`)) {
+          const server = readJSON(`${serverPath}/server.json`);
+
+          // Check if server is marked as expired
+          if (server.expired || server.markedExpired) {
+            // Server exists but is marked expired - restore it
+            recoveredServer = server;
+            recoveredServerId = serverId;
+            break; // Recover the first expired one found
+          }
+        }
+      }
+    }
+
+    if (recoveredServer) {
+      // Restore the server
+      recoveredServer.expired = false;
+      recoveredServer.markedExpired = false;
+      recoveredServer.restoredDate = Date.now();
+
+      writeJSON(`servers/${recoveredServerId}/server.json`, recoveredServer);
+
+      // Log recovery
+      console.log(`Server ${recoveredServerId} recovered for account ${email}`);
+
+      return res.status(200).json({
+        success: true,
+        message: "Your server has been restored! You can now start using it again.",
+        serverId: recoveredServerId,
+        serverName: recoveredServer.serverName || `Server ${recoveredServerId}`
+      });
+    } else {
+      // Server not found in servers directory - must be deleted/trashed
+      return res.status(200).json({
+        success: true,
+        message: "Your slot has been freed up. You have gone past the grace period, but you may still be able to recover your data. Please contact support for assistance.",
+        recovered: false
+      });
+    }
+  } catch (error) {
+    console.error("Recovery handler error:", error);
+    res.status(500).json({ success: false, message: "An error occurred during recovery" });
+  }
+}
+
+module.exports = router;

--- a/quartz/run.js
+++ b/quartz/run.js
@@ -1000,6 +1000,7 @@ app.use("/translate", require("./routes/translate"));
 app.use("/node", require("./routes/node"));
 app.use("/referrals", require("./routes/referrals"));
 app.use("/admin", require("./routes/admin.js"));
+app.use("/support", require("./routes/support.js"));
 
 //support for extensions
 

--- a/quartz/scripts/mc.js
+++ b/quartz/scripts/mc.js
@@ -794,12 +794,18 @@ function run(
           );
 
           forgeInstaller.stdout.on("data", (data) => {
-            terminalOutput[id] += "\n[Forge Installer] " + data.toString();
+            // Prevent stdout from growing unbounded (100MB limit)
+            if (terminalOutput[id].length < 100 * 1024 * 1024) {
+              terminalOutput[id] += "\n[Forge Installer] " + data.toString();
+            }
             console.log("[Forge " + id + "] " + data.toString());
           });
 
           forgeInstaller.stderr.on("data", (data) => {
-            terminalOutput[id] += "\n[Forge Error] " + data.toString();
+            // Prevent stderr from growing unbounded (100MB limit)
+            if (terminalOutput[id].length < 100 * 1024 * 1024) {
+              terminalOutput[id] += "\n[Forge Error] " + data.toString();
+            }
             console.log("[Forge Error " + id + "] " + data.toString());
           });
 
@@ -948,6 +954,10 @@ function run(
           }
 
             terminalOutput[id] = out.join("\n");
+            // Prune buffer if it exceeds 100MB
+            if (terminalOutput[id].length > 100 * 1024 * 1024) {
+              terminalOutput[id] = "[...pruned first 50MB of logs...]\n" + terminalOutput[id].slice(50 * 1024 * 1024);
+            }
             if (
               terminalOutput[id].includes("Done (") &&
               states[id] != "stopping"
@@ -968,8 +978,11 @@ function run(
           });
           ls.stderr.on("data", data => {
   const text = data.toString("utf8");
- terminalOutput[id]+= "\n" + text;
-     
+  // Prevent stderr from growing unbounded (100MB limit)
+  if (terminalOutput[id].length < 100 * 1024 * 1024) {
+    terminalOutput[id]+= "\n" + text;
+  }
+
     if (terminalOutput[id].includes("to the Docker daemon")) {
       terminalOutput[id] = "[Crash]: Docker is not properly setup. Contact an admin.";
       states[id] = "false";
@@ -1001,6 +1014,10 @@ function run(
             states[id] = "false";
             console.log("setting status of " + id + " to false on line #7");
             terminalOutput[id] = out.join("\n");
+            // Prune buffer if it exceeds 100MB
+            if (terminalOutput[id].length > 100 * 1024 * 1024) {
+              terminalOutput[id] = "[...pruned first 50MB of logs...]\n" + terminalOutput[id].slice(50 * 1024 * 1024);
+            }
             clearInterval(intervalID);
           });
         }
@@ -1029,6 +1046,10 @@ function run(
         }
 
         terminalOutput[id] = out.join("\n");
+        // Prune buffer if it exceeds 100MB
+        if (terminalOutput[id].length > 100 * 1024 * 1024) {
+          terminalOutput[id] = "[...pruned first 50MB of logs...]\n" + terminalOutput[id].slice(50 * 1024 * 1024);
+        }
         if (terminalOutput[id].includes("Done (") && states[id] != "stopping") {
           //replace states[id] with true
           states[id] = "true";
@@ -1044,7 +1065,10 @@ function run(
       });
 ls.stderr.on("data", data => {
   const text = data.toString("utf8");
- terminalOutput[id] += "\n" + text;
+  // Prevent stderr from growing unbounded (100MB limit)
+  if (terminalOutput[id].length < 100 * 1024 * 1024) {
+    terminalOutput[id] += "\n" + text;
+  }
     if (terminalOutput[id].includes("to the Docker daemon")) {
       terminalOutput[id] = "[Crash]: Docker is not properly setup. Contact an admin.";
       states[id] = "false";


### PR DESCRIPTION
396:
- Issue: Server expired due to failed payments, and when they were resolved they still had to open a ticket to get things restored.
- Fix: "My server  is expired and it shouldnt be" option in subscription tools. (WIP)
- Fix 2: Added extra info for why a server is "expired", the customer may not have even known the reason.

Sidenote: The 24-hour grace period for new servers to prevent them from being expired before the system checks with stripe was not functional. This may have caused some issues in the past.

405:
- Issue: The user upgraded their plan but the changes were not applied due to how the system works. The customer had to open a ticket.
- Fix: "Plan upgrade not applied" option in subscription tools.

425:
- Issue: Customer's server was expired despite having an active subscription
- Fix: While we don't know the actual cause yet and thus don't have a full fix, the subscription tools has a tool for restoring your expired server if it is incorrectly expired. This can prevent support tickets and make it so the dev team doesn't have to do it themselves.

Sidenote:

There was an issue called 424 where someone re-subscribed after a while and their server's slot was taken. We would manually have to move everything and even then the subdomains might not work. In the future, we should make a function that handles this but its outside of the scope of the PR since the goal is to prevent unneeded support tickets as soon as possible